### PR TITLE
Remove stray reference to React.PropTypes in ReactLink

### DIFF
--- a/src/addons/link/ReactLink.js
+++ b/src/addons/link/ReactLink.js
@@ -34,6 +34,7 @@
  * consumption of ReactLink easier; see LinkedValueUtils and LinkedStateMixin.
  */
 
+var PropTypes = require('prop-types');
 var React = require('React');
 
 /**
@@ -59,11 +60,11 @@ function ReactLink(value, requestChange) {
 function createLinkTypeChecker(linkType) {
   var shapes = {
     value: linkType === undefined
-      ? React.PropTypes.any.isRequired
+      ? PropTypes.any.isRequired
       : linkType.isRequired,
-    requestChange: React.PropTypes.func.isRequired,
+    requestChange: PropTypes.func.isRequired,
   };
-  return React.PropTypes.shape(shapes);
+  return PropTypes.shape(shapes);
 }
 
 ReactLink.PropTypes = {


### PR DESCRIPTION
**why make this change?:**
오래된 문법인 React.PropTypes 대신 PropTypes(prop-types모듈) 사용

**test plan:**
`yarn test`

**issue:**
#1