### PR TITLE
Use PropTypes from prop-types package

### DIFF
--- a/src/addons/link/ReactLink.js
+++ b/src/addons/link/ReactLink.js
@@ -35,6 +35,7 @@
  */
 
 var React = require('React');
+var PropTypes = require('prop-types');
 
 /**
  * Deprecated: An an easy way to express two-way binding with React. 
@@ -59,11 +60,11 @@ function ReactLink(value, requestChange) {
 function createLinkTypeChecker(linkType) {
   var shapes = {
     value: linkType === undefined
-      ? React.PropTypes.any.isRequired
+      ? PropTypes.any.isRequired
       : linkType.isRequired,
-    requestChange: React.PropTypes.func.isRequired,
+    requestChange: PropTypes.func.isRequired,
   };
-  return React.PropTypes.shape(shapes);
+  return PropTypes.shape(shapes);
 }
 
 ReactLink.PropTypes = {


### PR DESCRIPTION
**what is the change?:**
It looks like we missed updating this callsite in facebook/react@12a96b9

**why make this change?:**
We are deprecating the React.PropTypes syntax and splitting that functionality into a separate module.
please correct me if there is a reason we left this here.

**test plan:**
```
yarn test
```

**issue:**
#5 